### PR TITLE
Bugfix: BOT filepath mismatch for images

### DIFF
--- a/_meta/tg_districts.meta
+++ b/_meta/tg_districts.meta
@@ -50,8 +50,6 @@ Yadadri, Yadadri Bhuvanagiri
 Yadadri bhonigir,Yadadri Bhuvanagiri
 ADILABAD,Adilabad
 BHADRADRI KOTHAGUDEM,Bhadradri Kothagudem
-BHADRADRI KOTHAGUDEM,Bhadradri Kothagudem
-GHMC,Hyderabad
 GHMC,Hyderabad
 JAGTIAL,Jagtial
 JAGITYAL,Jagtial
@@ -59,7 +57,6 @@ JANGAON,Jangaon
 JAYASHANKAR BHUPALAPALLY,Jayashankar Bhupalapally
 JAYASHANKAR BHUPALPALLY,Jayashankar Bhupalapally
 JAYASHANKAR,Jayashankar Bhupalapally
-JOGULAMBA GADWAL,Jogulamba Gadwal
 JOGULAMBA GADWAL,Jogulamba Gadwal
 KAMAREDDY,Kamareddy
 KARIMNAGAR,Karimnagar
@@ -91,10 +88,8 @@ SURYAPET,Suryapet
 VIKARABAD,Vikarabad
 WANAPARTHY,Wanaparthy
 WARANGAL RURAL,Warangal Rural
-WARANGAL RURAL,Warangal Rural
 WARANGAL URBAN,Warangal Urban
 HANUMAKONDA,Warangal Urban
-WARANGAL URBAN,Warangal Urban
 YADADRI BHUVANAGIRI,Yadadri Bhuvanagiri
 YADADRI, Yadadri Bhuvanagiri
 YADADRI BHONIGIR,Yadadri Bhuvanagiri

--- a/_meta/tg_districts.meta
+++ b/_meta/tg_districts.meta
@@ -48,3 +48,53 @@ Warangal urban,Warangal Urban
 Yadadri Bhuvanagiri,Yadadri Bhuvanagiri
 Yadadri, Yadadri Bhuvanagiri
 Yadadri bhonigir,Yadadri Bhuvanagiri
+ADILABAD,Adilabad
+BHADRADRI KOTHAGUDEM,Bhadradri Kothagudem
+BHADRADRI KOTHAGUDEM,Bhadradri Kothagudem
+GHMC,Hyderabad
+GHMC,Hyderabad
+JAGTIAL,Jagtial
+JAGITYAL,Jagtial
+JANGAON,Jangaon
+JAYASHANKAR BHUPALAPALLY,Jayashankar Bhupalapally
+JAYASHANKAR BHUPALPALLY,Jayashankar Bhupalapally
+JAYASHANKAR,Jayashankar Bhupalapally
+JOGULAMBA GADWAL,Jogulamba Gadwal
+JOGULAMBA GADWAL,Jogulamba Gadwal
+KAMAREDDY,Kamareddy
+KARIMNAGAR,Karimnagar
+KHAMMAM,Khammam
+KOMARAM BHEEM,Komaram Bheem
+KOMARAMBHEEM ASIFABAD,Komaram Bheem
+KOMARAMBHEEM,Komaram Bheem
+MAHABUBABAD,Mahabubabad
+MAHABUBNAGAR,Mahabubnagar
+MAHABOOBNAGAR,Mahabubnagar
+MANCHERIAL,Mancherial
+MEDAK,Medak
+MEDCHAL MALKAJGIRI,Medchal Malkajgiri
+MEDCHAL MALKAJIGIRI,Medchal Malkajgiri
+MULUGU,Mulugu
+NAGARKURNOOL,Nagarkurnool
+NALGONDA,Nalgonda
+NARAYANPET,Narayanpet
+NIRMAL,Nirmal
+NIZAMABAD,Nizamabad
+PEDDAPALLI,Peddapalli
+RAJANNA SIRCILLA,Rajanna Sircilla
+RAJANNA SIRICILLA,Rajanna Sircilla
+RANGA REDDY,Ranga Reddy
+RANGAREDDY,Ranga Reddy
+SANGAREDDY,Sangareddy
+SIDDIPET,Siddipet
+SURYAPET,Suryapet
+VIKARABAD,Vikarabad
+WANAPARTHY,Wanaparthy
+WARANGAL RURAL,Warangal Rural
+WARANGAL RURAL,Warangal Rural
+WARANGAL URBAN,Warangal Urban
+HANUMAKONDA,Warangal Urban
+WARANGAL URBAN,Warangal Urban
+YADADRI BHUVANAGIRI,Yadadri Bhuvanagiri
+YADADRI, Yadadri Bhuvanagiri
+YADADRI BHONIGIR,Yadadri Bhuvanagiri

--- a/_meta/up_districts.meta
+++ b/_meta/up_districts.meta
@@ -51,6 +51,7 @@
   फर्रुखाबाद  ,Farrukhabad
   फरुखाबाद , Farrukhabad
   फर्रा खाबाद , Farrukhabad
+  फर्रु खाबाद , Farrukhabad
   फतेहपुर  ,  Fatehpur
   फिरोजाबाद , Firozabad
   क्रिरोजाबाद , Firozabad
@@ -82,6 +83,7 @@
   झाँसी  ,  Jhansi
   झांसी , Jhansi
   झााँसी , Jhansi
+  झाूँसी , Jhansi
   कानपुर नगर, Kanpur Nagar
   कानपुर  ,  Kanpur Nagar
   कौशाम्बी  , Kaushambi

--- a/googlevision.py
+++ b/googlevision.py
@@ -430,10 +430,10 @@ def printOutput():
         districtIndex = 0
 #If the rows are not numberd, this condition can be skipped. For UP bulletin, this makes sense.
         if(is_number(outputArray[0])):
-          districtName = outputArray[1].strip().capitalize()
+          districtName = outputArray[1].strip()#.capitalize()
           distrinctIndex = 1
         else:
-          districtName = outputArray[0].strip().capitalize()
+          districtName = outputArray[0].strip()#.capitalize()
           distrinctIndex = 0
 
 #Do a lookup for district name, if not found, discard the record and print a message.

--- a/read_pdf.py
+++ b/read_pdf.py
@@ -79,11 +79,7 @@ def read_pdf_from_url(opt):
 
         if opt['config']['start_key'] in line:
           startedReadingDistricts = True
-        if opt['state_code'] != 'TG':
-          if len(opt['config']['end_key']) > 0 and opt['config']['end_key'] in line:
-            startedReadingDistricts = False
-            continue
-        elif row[3] == "":
+        if len(opt['config']['end_key']) > 0 and opt['config']['end_key'] in line:
             startedReadingDistricts = False
             continue
 

--- a/read_pdf.py
+++ b/read_pdf.py
@@ -138,16 +138,13 @@ def ka_format_line(row):
 
 def hr_format_line(row):
   row[1] = re.sub('\*', '', row[1])
-  if '[' in row[3]:
-    row[3] = row[3].split('[')[0]
   if '[' in row[4]:
     row[4] = row[4].split('[')[0]
-  if '[' in row[6]:
-    row[6] = row[6].split('[')[0]
-  #if '[' in row[6]:
-  #  row[6] = row[6].split('[')[0]
-  #line = row[1] + "," + row[3] + "," + row[4] + "," + row[6] + "," + row[7] + "\n"
-  line = row[1] + "," + row[3] + "," + row[4] + "," + row[6] + "\n"
+  if '[' in row[5]:
+    row[5] = row[5].split('[')[0]
+  if '[' in row[7]:
+    row[7] = row[7].split('[')[0]
+  line = row[1] + "," + row[4] + "," + row[5] + "," + row[7] + "\n"
   return line
 
 def pb_format_line(row):

--- a/read_pdf.py
+++ b/read_pdf.py
@@ -194,6 +194,11 @@ def tn_format_line(row):
   line = row[1] + "," + row[2] + "," + row[3] + "," + row[4] +  "," + row[5] + "\n"
   return line
 
+def tg_format_line(row):
+    line = row[1] + "," + row[2] + "\n"
+    return line
+
+
 def vaccination_mohfw_format_line(row):
   line = row[1] + "," + ''.join(row[2].split(',')) + "," + ''.join(row[3].split(',')) + "," + ''.join(row[4].split(',')) + "\n"
   return line

--- a/read_pdf.py
+++ b/read_pdf.py
@@ -79,9 +79,14 @@ def read_pdf_from_url(opt):
 
         if opt['config']['start_key'] in line:
           startedReadingDistricts = True
-        if len(opt['config']['end_key']) > 0 and opt['config']['end_key'] in line:
-          startedReadingDistricts = False
-          continue
+        if opt['state_code'] != 'TG':
+          if len(opt['config']['end_key']) > 0 and opt['config']['end_key'] in line:
+            startedReadingDistricts = False
+            continue
+        elif row[3] == "":
+            startedReadingDistricts = False
+            continue
+
         if startedReadingDistricts == False:
           continue
 
@@ -195,8 +200,14 @@ def tn_format_line(row):
   return line
 
 def tg_format_line(row):
-    line = row[1] + "," + row[2] + "\n"
-    return line
+  #if row[2] != "":
+  line = row[1] + "," + row[2] + "\n"
+  #print(line)
+  return line
+  #elif "YADADRI" in row[2]:
+  #  line = row[1] + "," + row[2] + "\n"
+  #  print(line)
+  #  return line
 
 
 def vaccination_mohfw_format_line(row):

--- a/states.yaml
+++ b/states.yaml
@@ -482,10 +482,13 @@ tg:
     - https://twitter.com/Eatala_Rajender
     - https://covid19.telangana.gov.in/
     - https://covid19.telangana.gov.in/announcements/media-bulletins/
-  type: image
-  url: _inputs/tg.jpeg
+  type: pdf
+  url:
   config:
+    page: 2
     translation: False
+    start_key: ADILABAD
+    end_key: YADADRI
 
 tr:
   name: Tripura

--- a/states.yaml
+++ b/states.yaml
@@ -482,13 +482,13 @@ tg:
     - https://twitter.com/Eatala_Rajender
     - https://covid19.telangana.gov.in/
     - https://covid19.telangana.gov.in/announcements/media-bulletins/
-  type: pdf
-  url:
+  type: image
+  url: _inputs/tg/jpeg
   config:
     page: 2
     translation: False
-    start_key: ADILABAD
-    end_key: YADADRI
+    #start_key: ADILABAD
+    #end_key: 
 
 tr:
   name: Tripura

--- a/states.yaml
+++ b/states.yaml
@@ -487,8 +487,10 @@ tg:
   config:
     page: 2
     translation: False
-    #start_key: ADILABAD
-    #end_key: 
+    #Starting text: Adilabad
+    #Ending text: Yadadri
+    start_key: ADILABAD
+    #end_key: YADADRI BHONIGIR
 
 tr:
   name: Tripura

--- a/statewise_get_data.py
+++ b/statewise_get_data.py
@@ -729,43 +729,43 @@ def kl_get_data(opt):
 
     return districts_data
 
-  #   opt['url'] = 'https://dashboard.kerala.gov.in/index.php'
-  #   print('Fetching KL data', opt)
-  #   response = requests.request("GET", opt['url'])
+    #   opt['url'] = 'https://dashboard.kerala.gov.in/index.php'
+    #   print('Fetching KL data', opt)
+    #   response = requests.request("GET", opt['url'])
 
-  #   # sessionId = (response.headers['Set-Cookie']).split(';')[0].split('=')[1]
+    #   # sessionId = (response.headers['Set-Cookie']).split(';')[0].split('=')[1]
 
-  #   cookies = {
-  #     '_ga': 'GA1.3.594771251.1592531338',
-  #     '_gid': 'GA1.3.674470591.1592531338',
-  #     # 'PHPSESSID': sessionId,
-  #     '_gat_gtag_UA_162482846_1': '1'
-  #   }
+    #   cookies = {
+    #     '_ga': 'GA1.3.594771251.1592531338',
+    #     '_gid': 'GA1.3.674470591.1592531338',
+    #     # 'PHPSESSID': sessionId,
+    #     '_gat_gtag_UA_162482846_1': '1'
+    #   }
 
-  #   headers = {
-  #     'Connection': 'keep-alive',
-  #     'Accept': 'application/json, text/javascript, */*; q=0.01',
-  #     'X-Requested-With': 'XMLHttpRequest',
-  #     'Sec-Fetch-Site': 'same-origin',
-  #     'Sec-Fetch-Mode': 'cors',
-  #     'Sec-Fetch-Dest': 'empty',
-  #     'Referer': 'https://dashboard.kerala.gov.in/index.php',
-  #     'Accept-Language': 'en-US,en;q=0.9'
-  #   }
-  #   stateDashboard = requests.get(opt['url'], headers=headers).json()
+    #   headers = {
+    #     'Connection': 'keep-alive',
+    #     'Accept': 'application/json, text/javascript, */*; q=0.01',
+    #     'X-Requested-With': 'XMLHttpRequest',
+    #     'Sec-Fetch-Site': 'same-origin',
+    #     'Sec-Fetch-Mode': 'cors',
+    #     'Sec-Fetch-Dest': 'empty',
+    #     'Referer': 'https://dashboard.kerala.gov.in/index.php',
+    #     'Accept-Language': 'en-US,en;q=0.9'
+    #   }
+    #   stateDashboard = requests.get(opt['url'], headers=headers).json()
 
-  #   districtArray = []
-  #   for districtDetails in stateDashboard['features']:
-  #     districtDictionary = {}
-  #     districtDictionary['districtName'] = districtDetails['properties']['District']
-  #     districtDictionary['confirmed'] = districtDetails['properties']['covid_stat']
-  #     districtDictionary['recovered'] = districtDetails['properties']['covid_statcured']
-  #     districtDictionary['deceased'] = districtDetails['properties']['covid_statdeath']
-  #     districtArray.append(districtDictionary)
-  #   # deltaCalculator.getStateDataFromSite("Kerala", districtArray, option)
-  #   return districtArray
+    #   districtArray = []
+    #   for districtDetails in stateDashboard['features']:
+    #     districtDictionary = {}
+    #     districtDictionary['districtName'] = districtDetails['properties']['District']
+    #     districtDictionary['confirmed'] = districtDetails['properties']['covid_stat']
+    #     districtDictionary['recovered'] = districtDetails['properties']['covid_statcured']
+    #     districtDictionary['deceased'] = districtDetails['properties']['covid_statdeath']
+    #     districtArray.append(districtDictionary)
+    #   # deltaCalculator.getStateDataFromSite("Kerala", districtArray, option)
+    #   return districtArray
 
-  if opt['type'] == 'pdf':
+  elif opt['type'] == 'pdf':
 
     if opt['skip_output'] == False:
       read_pdf_from_url(opt)
@@ -1458,35 +1458,84 @@ def tg_get_data(opt):
   print('Fetching TG data')
   pprint(opt)
 
-  district_data = []
-  if opt['skip_output'] == False:
-    run_for_ocr(opt)
-  print('\n')
-  linesArray = []
-  districtDictionary = {}
+  print('\n*** Do Manual entry of Recovered and Deaths\nDistrictwise Hospitalized \n')
+  
+  if opt['type'] == 'pdf':
+    if opt['skip_output'] == False:
+      read_pdf_from_url(opt)
 
-  with open(OUTPUT_TXT, "r") as upFile:
-    for line in upFile:
-      linesArray = line.split('|')[0].split(',')
-      if len(linesArray) != 2:
-        print("--> Issue with Columns: Cno={} : {}".format(len(linesArray), linesArray))
-        print('--------------------------------------------------------------------------------')
-        continue
-      if linesArray[0].strip().capitalize() == "Ghmc":
-        linesArray[0] = "Hyderabad"
+    linesArray = []
+    districtDictionary = {}
+    district_data = []
+    ignoreLines = False
+    try:
+      csv_file = os.path.join(OUTPUTS_DIR, '{}.csv'.format(opt['state_code'].lower()))
+      with open(csv_file, "r") as upFile:
+        for line in upFile:
+          '''
+          if ignoreLines == True:
+            continue
 
-      districtDictionary['districtName'] = linesArray[0].strip().title()
-      districtDictionary['confirmed'] = int(linesArray[1].strip())
-      districtDictionary['recovered'] = 0
-      districtDictionary['deceased'] = 0
-      district_data.append(districtDictionary)
-      if linesArray[1].strip() != '0':
-        print("{},Telangana,TG,{},Hospitalized".format(linesArray[0].strip().title(), linesArray[1].strip()))
-      
-  print('\n')
-  upFile.close()
-  #quit()
-  # return district_data
+          if 'Total' in line:
+            ignoreLines = True
+            continue
+          '''
+          linesArray = line.split(',')
+          if len(linesArray) != 2:
+            print("--> Issue with Columns: Cno={} : {}".format(len(linesArray), linesArray))
+            print('--------------------------------------------------------------------------------')
+            continue
+          if linesArray[0].strip().capitalize() == "Ghmc":
+            linesArray[0] = "Hyderabad"
+
+          districtDictionary['districtName'] = linesArray[0].strip().title()
+          districtDictionary['confirmed'] = int(linesArray[1].strip())
+          districtDictionary['recovered'] = 0
+          districtDictionary['deceased'] = 0
+          #district_data.append(districtDictionary)
+          if linesArray[1].strip() != '0':
+            print("{},Telangana,TG,{},Hospitalized".format(linesArray[0].strip().title(), linesArray[1].strip()))
+
+      print('\n')
+      print('\nRecovery & Deaths available at state level file')
+      upFile.close()
+    except FileNotFoundError:
+      print("output.txt missing. Generate through pdf or ocr and rerun.")
+    return district_data
+
+  elif opt['type'] == 'image':
+    if opt['skip_output'] == False:
+      run_for_ocr(opt)
+
+    print('\n')
+    linesArray = []
+    districtDictionary = {}
+    district_data = []
+    ignoreLines = False
+
+    with open(OUTPUT_TXT, "r") as upFile:
+      for line in upFile:
+        linesArray = line.split('|')[0].split(',')
+        if len(linesArray) != 2:
+          print("--> Issue with Columns: Cno={} : {}".format(len(linesArray), linesArray))
+          print('--------------------------------------------------------------------------------')
+          continue
+        if linesArray[0].strip().capitalize() == "Ghmc":
+          linesArray[0] = "Hyderabad"
+
+        districtDictionary['districtName'] = linesArray[0].strip().title()
+        districtDictionary['confirmed'] = int(linesArray[1].strip())
+        districtDictionary['recovered'] = 0
+        districtDictionary['deceased'] = 0
+        #district_data.append(districtDictionary)
+        if linesArray[1].strip() != '0':
+          print("{},Telangana,TG,{},Hospitalized".format(linesArray[0].strip().title(), linesArray[1].strip()))
+        
+    print('\n')
+    print('\nRecovery & Deaths available at state level in Image-1')
+    upFile.close()
+  #return district_data
+
 
 def tr_get_data(opt):
   print('fetching TR data')
@@ -1542,10 +1591,11 @@ def up_get_data(opt):
         # districtDictionary['migrated'] = int(re.sub('\n', '', linesArray[5].strip()))
         districts_data.append(districtDictionary)
 
+    print('\n')
     upFile.close()
   except FileNotFoundError:
     print("_outputs/output.txt missing. Generate through pdf or ocr and rerun.")
-  return districts_data
+  #return districts_data
 
 def ut_get_data(opt):
   print('Fetching UT data')

--- a/statewise_get_data.py
+++ b/statewise_get_data.py
@@ -1482,16 +1482,16 @@ def tg_get_data(opt):
           '''
           linesArray = line.split(',')
           if len(linesArray) != 2:
-            print("--> Issue with Columns: Cno={} : {}".format(len(linesArray), linesArray))
+            print("=====> Issue with Columns: Cno={} : {}".format(len(linesArray), linesArray))
             print('--------------------------------------------------------------------------------')
             continue
           if linesArray[0].strip().capitalize() == "Ghmc":
             linesArray[0] = "Hyderabad"
 
-          districtDictionary['districtName'] = linesArray[0].strip().title()
-          districtDictionary['confirmed'] = int(linesArray[1].strip())
-          districtDictionary['recovered'] = 0
-          districtDictionary['deceased'] = 0
+          #districtDictionary['districtName'] = linesArray[0].strip().title()
+          #districtDictionary['confirmed'] = int(linesArray[1].strip())
+          #districtDictionary['recovered'] = 0
+          #districtDictionary['deceased'] = 0
           #district_data.append(districtDictionary)
           if linesArray[1].strip() != '0':
             print("{},Telangana,TG,{},Hospitalized".format(linesArray[0].strip().title(), linesArray[1].strip()))
@@ -1501,7 +1501,7 @@ def tg_get_data(opt):
       upFile.close()
     except FileNotFoundError:
       print("output.txt missing. Generate through pdf or ocr and rerun.")
-    return district_data
+    #return district_data
 
   elif opt['type'] == 'image':
     if opt['skip_output'] == False:
@@ -1517,16 +1517,16 @@ def tg_get_data(opt):
       for line in upFile:
         linesArray = line.split('|')[0].split(',')
         if len(linesArray) != 2:
-          print("--> Issue with Columns: Cno={} : {}".format(len(linesArray), linesArray))
+          print("=====> Issue with Columns: Cno={} : {}".format(len(linesArray), linesArray))
           print('--------------------------------------------------------------------------------')
           continue
         if linesArray[0].strip().capitalize() == "Ghmc":
           linesArray[0] = "Hyderabad"
 
-        districtDictionary['districtName'] = linesArray[0].strip().title()
-        districtDictionary['confirmed'] = int(linesArray[1].strip())
-        districtDictionary['recovered'] = 0
-        districtDictionary['deceased'] = 0
+        #districtDictionary['districtName'] = linesArray[0].strip().title()
+        #districtDictionary['confirmed'] = int(linesArray[1].strip())
+        #districtDictionary['recovered'] = 0
+        #districtDictionary['deceased'] = 0
         #district_data.append(districtDictionary)
         if linesArray[1].strip() != '0':
           print("{},Telangana,TG,{},Hospitalized".format(linesArray[0].strip().title(), linesArray[1].strip()))
@@ -1534,7 +1534,7 @@ def tg_get_data(opt):
     print('\n')
     print('\nRecovery & Deaths available at state level in Image-1')
     upFile.close()
-  #return district_data
+  return district_data
 
 
 def tr_get_data(opt):

--- a/statewise_get_data.py
+++ b/statewise_get_data.py
@@ -1150,7 +1150,9 @@ def nl_get_data(opt):
         districtDictionary['confirmed'] = int(linesArray[12])
         districtDictionary['recovered'] = int(linesArray[7])
         districtDictionary['migrated'] = int(linesArray[11])
-        districtDictionary['deceased'] = int(linesArray[8]) if len(re.sub('\n', '', linesArray[8])) != 0 else 0
+        #districtDictionary['deceased'] = int(linesArray[8]) if len(re.sub('\n', '', linesArray[8])) != 0 else 0
+        #NL now has deaths due to other couses as separate column
+        districtDictionary['deceased'] = int(linesArray[8]) + int(linesArray[9])
         districts_data.append(districtDictionary)
 
     upFile.close()

--- a/telegram_bot/entry.py
+++ b/telegram_bot/entry.py
@@ -156,7 +156,7 @@ def entry(bot, update):
                     image_path = os.path.join(DOWNLD_DIR, '{}.jpeg'.format(opt['state_code'].lower()))
 
                 image_file = bot.get_file(photo.file_id)
-                image_file.download()
+                image_file.download(image_path)
 
                 opt['url'] = image_path
                 bot.send_message(


### PR DESCRIPTION
line 159 of telegram_bot/entry.py
image_file.download()

this makes images saved in work directory and scraper look at
opt['url'] = image_path

none of the uploaded images will be processed and bot resorts to old files saved in _inputs or give an error file not found.

it is also sensible to have clean _inputs and _outputs in BOT whenever BOT is restarted. 
think about it