### PR TITLE
Cowin Districts vaccination update

### DIFF
--- a/vaccination.py
+++ b/vaccination.py
@@ -320,6 +320,10 @@ def get_cowin_district(from_date, to_date, state_codes):
     final_df = pd.concat(multi_dfs, axis=1)
     final_dwnld_df = pd.concat(multi_dwnld_dfs, axis=1)
 
+    #removing state_code,state_name, district_name columns
+    #they are redundant for updating sheet
+    final_df.drop(final_df.iloc[:,0:3], inplace=True, axis=1)
+
     final_df.to_csv(VACC_DST, index=False)
     final_dwnld_df.to_csv(COWIN_DIST_LIVE, index=False)
     print("District data is saved to: ", VACC_DST)


### PR DESCRIPTION
Printout of Cowin vaccination for districts.
Removed first 3 columns (state_code, state_name, district_name) which are redundant for sheet updates