### PR TITLE
Fix for Cowin district vaccination prints float format

### DIFF
--- a/vaccination.py
+++ b/vaccination.py
@@ -323,8 +323,8 @@ def get_cowin_district(from_date, to_date, state_codes):
     #Removing first 3 columns (state_code, state_name, district_name)
     final_df.drop(final_df.iloc[:,0:3], inplace=True, axis=1)
 
-    final_df.to_csv(VACC_DST, index=False)
-    final_dwnld_df.to_csv(COWIN_DIST_LIVE, index=False)
+    final_df.to_csv(VACC_DST, index=False, float_format = '%.0f')
+    final_dwnld_df.to_csv(COWIN_DIST_LIVE, index=False, float_format = '%.0f')
     print("District data is saved to: ", VACC_DST)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Cowin districts extract started printing float format 1234.0. this is not accepted by parser leading to missing data.
Patched csv writing with float_format.