### PR TITLE
RJ patch to handle both image and pdf

### DIFF
--- a/generate_ocrconfig.sh
+++ b/generate_ocrconfig.sh
@@ -42,6 +42,7 @@ replacementLine=$( customiseMetaConfig $stateCode $replacementLine "ut:houghTran
 #replacementLine=$( customiseMetaConfig $stateCode $replacementLine "nl:configMinLineLength=250,yInterval=5" )
 replacementLine=$( customiseMetaConfig $stateCode $replacementLine "nl:houghTransform=False,yInterval=5" )
 replacementLine=$( customiseMetaConfig $stateCode $replacementLine "mh:houghTransform=False,yInterval=15" )
+replacementLine=$( customiseMetaConfig $stateCode $replacementLine "rj:houghTransform=False,yInterval=5" )
 replacementLine=$( customiseMetaConfig $stateCode $replacementLine "up:houghTransform=False,configMinLineLength=200,yInterval=12" )
 
 configMinLineLength=400

--- a/scrapers.py
+++ b/scrapers.py
@@ -111,6 +111,11 @@ def run(args):
             'url': url,
             'type': url_type
         })
+    #Remove start_key and end_key for processing image of RJ
+    if url_type == 'image' and state_code == 'rj':
+      keys_to_remove = ['key_not_exist', 'start_key','end_key']
+      k = list(map( states_all[state_code]['config'].pop, keys_to_remove, keys_to_remove))
+
     live_data = fetch_data(states_all[state_code])
 
     if 'needs_correction' in live_data and live_data['needs_correction'] == True:

--- a/states.yaml
+++ b/states.yaml
@@ -441,15 +441,10 @@ rj:
   state_code: RJ
   cowin_code: 29
   url_sources:
-    - Check @c19b_data_dump telegram channel
-  # type: image
-  # url: _inputs/rj.jpeg
-  # config:
-  #   start_key: auto
-  #   end_key: auto
-  #   translation: True
+    - Check @c19b_data_dump telegram channel for PDF file
+    - image file from https://twitter.com/dineshkumawat
   type: pdf
-  url: _inputs/rj.pdf
+  url: 
   config:
     page: 1,2
     translation: False

--- a/statewise_get_data.py
+++ b/statewise_get_data.py
@@ -1774,64 +1774,48 @@ def rj_get_data(opt):
     if opt['skip_output'] == False:
       run_for_ocr(opt)
 
+    print('\n+++++++++++++++++++++++++++++++++++++++++++++++')   
+    print('Direct Deltas from bulletin. Pl check state totals')
+    print('+++++++++++++++++++++++++++++++++++++++++++++++\n') 
+
     skipValues = False
     edge_case = False
-    try:
-      with open(OUTPUT_TXT, "r") as upFile:
-        for line in upFile:
-          if 'Other' in line:
-            skipValues = True
-            continue
-          if skipValues == True:
-            continue
+    needs_correction = False
+    to_correct = []      
+    with open(OUTPUT_TXT, "r") as upFile:
+      for line in upFile:
+        if 'Other' in line:
+          skipValues = True
+          continue
+        if skipValues == True:
+          continue
 
-          linesArray = line.split('|')[0].split(',')
+        linesArray = line.split('|')[0].split(',')
 
-          if len(linesArray) != 9:
-            needs_correction = True
-            linesArray.insert(0, '--> Issue with')
-            to_correct.append(linesArray)
-            continue
+        NcolReq = 6
+        if len(linesArray) != NcolReq:
+          NcolErr = '--> Ncol='+str(len(linesArray))+' (NcolReq='+str(NcolReq)+')'
+          needs_correction = True
+          linesArray.insert(0, NcolErr)
+          to_correct.append(linesArray)
+          continue
 
-          districtDictionary = {}
+        if 'Other' in linesArray[0].strip().title():
+          print('\n+++++++++++++++++++++++++++++++++++++++++++++++')   
+          print('Ignoring Other States/Countries',linesArray[0].strip())
+          continue
 
-          if 'Other' in linesArray[0].strip().title():
-            continue
-
-          if linesArray[0].strip().title() != 'Ganganagar':
-            districtDictionary['districtName'] = linesArray[0].strip().title()
-            edge_case = False
-          else:
-            edge_case = True
-
-          if edge_case:
-            # only for Ganaganagar
-            cf = re.sub(r'[a-z]+', '', linesArray[4])
-            dt = re.sub(r'\)', '', linesArray[6])
-            rc = re.sub(r'[a-z]+', '', linesArray[7])
-            districtDictionary['confirmed'] = int(cf.strip())
-            districtDictionary['recovered'] = int(rc.strip())
-            districtDictionary['deceased'] = int(dt.strip())
-          else:
-            rc = re.sub(r'[a-z]+', '', linesArray[7])
-            districtDictionary['confirmed'] = int(linesArray[3].strip())
-            districtDictionary['recovered'] = int(linesArray[7].strip())
-            districtDictionary['deceased'] = int(linesArray[5].strip())
-          district_data.append(districtDictionary)
-    except Exception as e:
-      return {
-        'needs_correction': True,
-        'to_correct': e,
-        'output': OUTPUT_TXT
-      }
+        if linesArray[2].strip() != '0':
+          print("{},Rajasthan,RJ,{},Hospitalized".format(linesArray[0].strip().title(), linesArray[2].strip()))
+        if linesArray[4].strip() != '0':
+          print("{},Rajasthan,RJ,{},Recovered".format(linesArray[0].strip().title(), linesArray[4].strip()))
+        if linesArray[3].strip() != '0':
+          print("{},Rajasthan,RJ,{},Deceased".format(linesArray[0].strip().title(), linesArray[3].strip()))
 
     upFile.close()
-    if needs_correction:
-      return {
-        'needs_correction': True,
-        'to_correct': to_correct,
-        'output': OUTPUT_TXT
-      }
+    return {
+      'needs_correction': False,
+    }
 
   if opt['type'] == 'pdf':
     if opt['skip_output'] == False:
@@ -1874,10 +1858,10 @@ def rj_get_data(opt):
 
         if linesArray[1].strip() != '0':
           print("{},Rajasthan,RJ,{},Hospitalized".format(linesArray[0].strip().title(), linesArray[1].strip()))
-        if linesArray[2].strip() != '0':
-          print("{},Rajasthan,RJ,{},Deceased".format(linesArray[0].strip().title(), linesArray[2].strip()))
         if linesArray[3].strip() != '0':
           print("{},Rajasthan,RJ,{},Recovered".format(linesArray[0].strip().title(), linesArray[3].strip()))
+        if linesArray[2].strip() != '0':
+          print("{},Rajasthan,RJ,{},Deceased".format(linesArray[0].strip().title(), linesArray[2].strip()))
 
     upFile.close()
     return {


### PR DESCRIPTION
RJ now can handle both PDF and images
updated image scrapping part of RJ
put trap in scrapper.py to remove start & end keys when handling images (they are required for PDF)
additional states can be added into this check if required.